### PR TITLE
feat: product read, product registration 읽기 엔드포인트 보완 작업

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from fastapi import FastAPI, APIRouter
 from fastapi.middleware.cors import CORSMiddleware
 
 from api.v1.endpoints.macro import router as macro_router
-from api.v1.endpoints.product import router as products_router
+from api.v1.endpoints.product_bulk_tool import router as products_router
 from api.v1.endpoints.ecount.erp import router as ecount_router
 from api.v1.endpoints.receive_order import router as receive_order_router
 from api.v1.endpoints.mall_price import router as mall_price_router

--- a/repository/product_repository.py
+++ b/repository/product_repository.py
@@ -22,8 +22,23 @@ class ProductRepository:
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
-    async def get_products(self, page: int) -> list[ProductRawData]:
-        query = select(ProductRawData).offset((page - 1) * 20).limit(20).order_by(ProductRawData.created_at.desc())
+    async def get_products_all(self, skip: int, limit: int) -> list[ProductRawData]:
+        query = (
+            select(ProductRawData)
+            .offset(skip)
+            .limit(limit)
+            .order_by(ProductRawData.created_at.desc())
+        )
+        result = await self.session.execute(query)
+        return result.scalars().all()
+
+    async def get_products_by_pagenation(self, page: int, page_size: int) -> list[ProductRawData]:
+        query = (
+            select(ProductRawData)
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+            .order_by(ProductRawData.created_at.desc())
+        )
         result = await self.session.execute(query)
         return result.scalars().all()
 

--- a/schemas/product_registration/__init__.py
+++ b/schemas/product_registration/__init__.py
@@ -3,6 +3,9 @@ Product Registration 스키마 초기화
 """
 
 from .product_registration_dto import (
+    ProductRegistrationDto,
+    ProductRegistrationReadResponse,
+    ProductRegistrationPaginationReadResponse,
     ProductRegistrationCreateDto,
     ProductRegistrationResponseDto,
     ProductRegistrationBulkCreateDto,
@@ -13,6 +16,9 @@ from .product_registration_dto import (
 )
 
 __all__ = [
+    "ProductRegistrationDto",
+    "ProductRegistrationReadResponse",
+    "ProductRegistrationPaginationReadResponse",
     "ProductRegistrationCreateDto",
     "ProductRegistrationResponseDto", 
     "ProductRegistrationBulkCreateDto",

--- a/schemas/product_registration/product_registration_dto.py
+++ b/schemas/product_registration/product_registration_dto.py
@@ -4,13 +4,84 @@ Product Registration DTOs
 """
 
 import logging
-from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, Field
+from decimal import Decimal
 from datetime import datetime
+from typing import Optional, Any
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
 logger.info("Product Registration DTO 모듈 로드 시작...")
+
+
+class ProductRegistrationDto(BaseModel):
+    """상품 등록 DTO"""
+        # 기본 정보
+    id: int = Field(..., description="고유 식별자")
+
+    # 상품 기본 정보
+    product_nm: Optional[str] = Field(None, description="제품명")
+    goods_nm: Optional[str] = Field(None, description="상품명")
+    detail_path_img: Optional[str] = Field(None, description="상세페이지경로(이미지폴더)")
+
+    # 배송 및 가격 정보
+    delv_cost: Optional[Decimal] = Field(None, description="배송비")
+    goods_search: Optional[str] = Field(None, description="키워드")
+    goods_price: Optional[Decimal] = Field(None, description="판매가(유료배송)")
+    stock_use_yn: Optional[str] = Field(None, description="재고관리사용여부")
+
+    # 인증 및 진행 옵션
+    certno: Optional[str] = Field(None, description="인증번호")
+    char_process: Optional[str] = Field(None, description="진행옵션 가져오기")
+
+    # 옵션 정보
+    char_1_nm: Optional[str] = Field(None, description="옵션명1")
+    char_1_val: Optional[str] = Field(None, description="옵션상세1")
+    char_2_nm: Optional[str] = Field(None, description="옵션명2")
+    char_2_val: Optional[str] = Field(None, description="옵션상세2")
+
+    # 이미지 정보
+    img_path: Optional[str] = Field(None, description="대표이미지")
+    img_path1: Optional[str] = Field(None, description="종합몰(JPG)이미지")
+    img_path2: Optional[str] = Field(None, description="부가이미지2")
+    img_path3: Optional[str] = Field(None, description="부가이미지3")
+    img_path4: Optional[str] = Field(None, description="부가이미지4")
+    img_path5: Optional[str] = Field(None, description="부가이미지5")
+
+    # 상세 정보
+    goods_remarks: Optional[str] = Field(None, description="상세설명")
+    mobile_bn: Optional[str] = Field(None, description="모바일배너")
+    one_plus_one_bn: Optional[str] = Field(None, description="1+1배너")
+    goods_remarks_url: Optional[str] = Field(None, description="상세설명url")
+    delv_one_plus_one: Optional[str] = Field(None, description="1+1옵션(배송)")
+    delv_one_plus_one_detail: Optional[str] = Field(None, description="1+1옵션상세")
+
+    # 카테고리 정보
+    class_nm1: Optional[str] = Field(None, description="대분류_분류명")
+    class_nm2: Optional[str] = Field(None, description="중분류_분류명")
+    class_nm3: Optional[str] = Field(None, description="소분류_분류명")
+    class_nm4: Optional[str] = Field(None, description="세분류_분류명")
+
+    # 타임스탬프
+    created_at: datetime = Field(..., description="생성일시")
+    updated_at: datetime = Field(..., description="수정일시")
+
+    class Config:
+        from_attributes = True
+
+
+class ProductRegistrationReadResponse(BaseModel):
+    """상품 등록 조회 응답 DTO"""
+    item_count: int = Field(..., description="상품 목록 개수")
+    product_registration_dto_list: list[ProductRegistrationDto] = Field(..., description="상품 목록")
+    
+    
+class ProductRegistrationPaginationReadResponse(BaseModel):
+    """상품 등록 페이징 조회 응답 DTO"""
+    current_page: int = Field(..., description="현재 페이지")
+    page_size: int = Field(..., description="페이지 크기")
+    item_count: int = Field(..., description="상품 목록 개수")
+    product_registration_dto_list: list[ProductRegistrationDto] = Field(..., description="상품 목록")
 
 
 class ProductRegistrationCreateDto(BaseModel):
@@ -124,7 +195,7 @@ logger.info("ProductRegistrationResponseDto 정의 완료")
 
 class ProductRegistrationBulkCreateDto(BaseModel):
     """대량 상품 등록 생성 DTO"""
-    data: List[ProductRegistrationCreateDto] = Field(..., description="상품 등록 데이터 목록")
+    data: list[ProductRegistrationCreateDto] = Field(..., description="상품 등록 데이터 목록")
 
 
 logger.info("ProductRegistrationBulkCreateDto 정의 완료")
@@ -134,9 +205,9 @@ class ProductRegistrationBulkResponseDto(BaseModel):
     """대량 상품 등록 응답 DTO"""
     success_count: int = Field(..., description="성공한 데이터 수")
     error_count: int = Field(..., description="실패한 데이터 수")
-    created_ids: List[int] = Field(..., description="생성된 데이터 ID 목록")
-    errors: List[str] = Field(..., description="오류 메시지 목록")
-    success_data: List[ProductRegistrationResponseDto] = Field(..., description="성공한 데이터 목록")
+    created_ids: list[int] = Field(..., description="생성된 데이터 ID 목록")
+    errors: list[str] = Field(..., description="오류 메시지 목록")
+    success_data: list[ProductRegistrationResponseDto] = Field(..., description="성공한 데이터 목록")
 
 
 logger.info("ProductRegistrationBulkResponseDto 정의 완료")
@@ -147,8 +218,8 @@ class ExcelProcessResultDto(BaseModel):
     total_rows: int = Field(..., description="총 행 수")
     valid_rows: int = Field(..., description="유효한 행 수")
     invalid_rows: int = Field(..., description="무효한 행 수")
-    validation_errors: List[str] = Field(..., description="검증 오류 목록")
-    processed_data: List[ProductRegistrationCreateDto] = Field(..., description="처리된 데이터 목록")
+    validation_errors: list[str] = Field(..., description="검증 오류 목록")
+    processed_data: list[ProductRegistrationCreateDto] = Field(..., description="처리된 데이터 목록")
 
 
 logger.info("ExcelProcessResultDto 정의 완료")
@@ -168,10 +239,10 @@ class CompleteWorkflowResponseDto(BaseModel):
     """전체 워크플로우 응답 DTO"""
     success: bool = Field(..., description="처리 성공 여부")
     message: str = Field(..., description="처리 결과 메시지")
-    excel_processing: Dict[str, Any] = Field(..., description="Excel 처리 결과")
-    database_result: Dict[str, Any] = Field(..., description="데이터베이스 저장 결과")
-    transfer_result: Dict[str, Any] = Field(..., description="DB Transfer 결과")
-    sabang_api_result: Dict[str, Any] = Field(..., description="사방넷 API 요청 결과")
+    excel_processing: dict[str, Any] = Field(..., description="Excel 처리 결과")
+    database_result: dict[str, Any] = Field(..., description="데이터베이스 저장 결과")
+    transfer_result: dict[str, Any] = Field(..., description="DB Transfer 결과")
+    sabang_api_result: dict[str, Any] = Field(..., description="사방넷 API 요청 결과")
     error: Optional[str] = Field(None, description="오류 메시지")
 
 

--- a/services/product/product_read_service.py
+++ b/services/product/product_read_service.py
@@ -21,8 +21,13 @@ class ProductReadService:
         self.session = session
         self.product_repository = ProductRepository(session)
 
-    async def get_products_by_pagenation(self, page: int) -> list[ProductRawDataDto]:
-        products = await self.product_repository.get_products(page=page)
+    async def get_products_all(self, skip: int, limit: int) -> list[ProductRawDataDto]:
+        products = await self.product_repository.get_products_all(skip=skip, limit=limit)
+        dtos = [ProductRawDataDto.model_validate(product) for product in products]
+        return dtos
+
+    async def get_products_by_pagenation(self, page: int, page_size: int) -> list[ProductRawDataDto]:
+        products = await self.product_repository.get_products_by_pagenation(page=page, page_size=page_size)
         dtos = [ProductRawDataDto.model_validate(product) for product in products]
         return dtos
 

--- a/services/product_registration/__init__.py
+++ b/services/product_registration/__init__.py
@@ -4,8 +4,10 @@ Product Registration Services
 
 from .product_registration_service import ProductRegistrationService
 from .product_integrated_service import ProductCodeIntegratedService
+from .product_registration_read_service import ProductRegistrationReadService
 
 __all__ = [
     "ProductRegistrationService",
-    "ProductCodeIntegratedService"
+    "ProductCodeIntegratedService",
+    "ProductRegistrationReadService"
 ]

--- a/services/product_registration/product_registration_read_service.py
+++ b/services/product_registration/product_registration_read_service.py
@@ -1,12 +1,28 @@
-from typing import Tuple
-from decimal import Decimal
 from sqlalchemy.ext.asyncio import AsyncSession
 from repository.product_registration_repository import ProductRegistrationRepository
 from models.product.product_registration_data import ProductRegistrationRawData
+from schemas.product_registration import ProductRegistrationDto
+
 
 class ProductRegistrationReadService:
     def __init__(self, session: AsyncSession):
         self.product_registration_repository = ProductRegistrationRepository(session)
     
-    async def get_product_id_and_price_by_product_nm(self, product_nm: str) -> Tuple[int, Decimal]:
-        return await self.product_registration_repository.find_product_id_and_price_by_product_nm(product_nm)
+    async def get_products_all(self, skip: int = 0, limit: int = 100) -> list[ProductRegistrationDto]:
+        products: list[ProductRegistrationRawData] = (
+            await self
+            .product_registration_repository
+            .get_products_all(skip=skip, limit=limit)
+        )
+        return [ProductRegistrationDto.model_validate(product) for product in products]
+    
+    async def get_products_by_pagenation(self, page: int = 1, page_size: int = 20) -> list[ProductRegistrationDto]:
+        products: list[ProductRegistrationRawData] = (
+            await self
+            .product_registration_repository
+            .get_products_by_pagenation(
+                page=page, page_size=page_size
+            )
+        )
+        return [ProductRegistrationDto.model_validate(product) for product in products]
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,7 @@ def client(test_app: FastAPI) -> Generator[TestClient, Any, None]:
         global_mocks = {}
         
         # Product 관련 의존성
-        from api.v1.endpoints.product import get_product_read_service, get_product_update_service, get_product_db_xml_usecase
+        from api.v1.endpoints.product_bulk_tool import get_product_read_service, get_product_update_service, get_product_db_xml_usecase
         from services.product.product_read_service import ProductReadService
         from services.product.product_update_service import ProductUpdateService
         from services.usecase.product_db_xml_usecase import ProductDbXmlUsecase

--- a/tests/fixtures/product/conftest.py
+++ b/tests/fixtures/product/conftest.py
@@ -5,7 +5,7 @@ from services.product.product_read_service import ProductReadService
 from services.product.product_update_service import ProductUpdateService
 from services.usecase.product_db_xml_usecase import ProductDbXmlUsecase
 from utils.make_xml.product_registration_xml import ProductRegistrationXml
-from api.v1.endpoints.product import get_product_read_service, get_product_update_service, get_product_db_xml_usecase
+from api.v1.endpoints.product_bulk_tool import get_product_read_service, get_product_update_service, get_product_db_xml_usecase
 
 
 @pytest.fixture


### PR DESCRIPTION
## feat(product-read): 상품 등록 조회 API 추가 및 Product Bulk Tool 라우터 정리

### 🎯 개요
- 상품 등록 원천 데이터 조회용 API 추가
- 기존 `product` 엔드포인트 구조를 `product-bulk-tool`로 정리 및 신규 라우터 도입
- DB → XML → 사방넷 요청 플로우를 명확히 분리/정리
- 테스트 환경에서 Alembic 자동 마이그레이션 적용

### 🔄 변경 사항
- **엔드포인트 추가/이관**
  - `DELETE api/v1/endpoints/product.py` → 기능을 `api/v1/endpoints/product_bulk_tool.py`로 재구성
  - `GET /api/v1/product-registration` 목록 조회
  - `GET /api/v1/product-registration/pagenation` 페이지네이션 조회
  - `POST /api/v1/product-registration/excel/process` 엑셀 검증 처리
  - `POST /api/v1/product-registration/excel/import` 엑셀 → DB 저장
  - `POST /api/v1/product-registration/complete-workflow` 엑셀→DB→Transfer→사방넷 통합
  - `POST /api/v1/product-registration/local-excel/import` 로컬 엑셀 → DB 저장
  - `POST /api/v1/product-registration/create` 단건 생성
  - `POST /api/v1/product-registration/bulk-create` 대량 생성
  - `GET /api/v1/product-registration/list` 목록 조회 (응답 단순형)
  - `GET /api/v1/product-registration/{product_id}` 단건 조회
  - `GET /api/v1/product-registration/search/?q=...` 검색
  - `PUT /api/v1/product-registration/{product_id}` 업데이트
  - `DELETE /api/v1/product-registration/{product_id}` 삭제
  - `GET /api/v1/product-bulk-tool/all` 원천(product_raw_data) 전체 조회
  - `GET /api/v1/product-bulk-tool/pagenation` 원천 페이지네이션 조회
  - `POST /api/v1/product-bulk-tool/db-to-xml-all/sabangnet-request` DB → XML → 사방넷 요청
  - `GET /api/v1/product-bulk-tool/bulk/db-to-excel` DB → Excel 다운로드

- **스키마**
  - `schemas/product_registration/product_registration_dto.py`
    - `ProductRegistrationDto`, `ProductRegistrationReadResponse`, `ProductRegistrationPaginationReadResponse`
    - `ProductRegistrationCreateDto`, `ProductRegistrationResponseDto`
    - 대량 처리용 `ProductRegistrationBulkCreateDto`, `ProductRegistrationBulkResponseDto`
    - 워크플로우 응답용 `ExcelProcessResultDto`, `ExcelImportResponseDto`, `CompleteWorkflowResponseDto`
  - Pydantic v2 기반. ORM 매핑 시 `from_attributes=True` 필요
    - 권장: DTO 내부에 `from_attributes=True` 설정 또는 서비스에서 `model_validate(..., from_attributes=True)`

- **서비스/레포지토리**
  - 서비스: `services/product_registration/product_registration_read_service.py`
    - `get_products_all(skip, limit)`, `get_products_by_pagenation(page, page_size)` 추가
  - 레포: `repository/product_registration_repository.py`
    - `get_products_all`, `get_products_by_pagenation` 정렬/오프셋/리밋 적용
  - 레포: `repository/product_repository.py`
    - 원천 데이터 조회/변환 관련 정리

- **앱 라우팅**
  - `main.py`에서 `/api/v1` 하위에 `product_registration`, `product-bulk-tool` 라우터 포함

- **테스트**
  - `tests/conftest.py`에서 Alembic 마이그레이션 세션 자동 적용 및 의존성 오버라이드 정리
  - `tests/fixtures/product/conftest.py`에서 product-bulk-tool 의존성 오버라이드 픽스처 추가

### 🆕 주요 신규·변경 기능
- **상품 등록 원천 데이터 조회 API**: 백오피스/툴 연동을 위한 리스트/페이지네이션 조회 제공
- **엑셀 파이프라인 고도화**: 엑셀 검증/저장/통합 워크플로우 API로 분리 제공
- **Product Bulk Tool 라우터 분리**: 원천 데이터용 라우터를 `/product-bulk-tool`로 통합

### 🏗️ 아키텍처 개선사항
- 라우터 분리로 책임 명확화: `product-registration`(원천 등록 관리) vs `product-bulk-tool`(대량 등록 유틸)
- 레이어드 아키텍처 정리: Router → Service → Repository 경유
- DTO 응답 명확화: 조회·페이지네이션 응답 모델 구분

### 🔄 처리 플로우
- 엑셀 업로드: Excel → 검증(`.../excel/process`) → 저장(`.../excel/import`)
- 통합 워크플로우: Excel → DB 저장 → DB Transfer → 사방넷 요청(`.../complete-workflow`)
- 원천 조회: DB → `/product-registration` or `/product-bulk-tool`

### 🔍 데이터 스키마 변경
- 신규 DTO 도입(상세 필드 추가) 및 응답 래핑 모델 도입
- Pydantic v2 전환에 따른 ORM 매핑 옵션 필요
  - DTO에 `from_attributes=True` 추가 권장
  - 또는 서비스에서 `model_validate(obj, from_attributes=True)` 사용

### 🧩 Frontend 연동 가이드
- 기본 프리픽스: `/api/v1`
- 신규/변경 엔드포인트
  - `GET /product-registration?skip=<int>&limit=<int>`
    - 응답: `ProductRegistrationReadResponse`
  - `GET /product-registration/pagenation?page=<int>&page_size=<int>`
    - 응답: `ProductRegistrationPaginationReadResponse`
  - `GET /product-bulk-tool/all?skip=<int>&limit=<int>`
    - 응답: `ProductPageResponse`
  - `GET /product-bulk-tool/pagenation?page=<int>&page_size=<int>`
    - 응답: `ProductPageResponse`
- 브레이킹 체인지
  - 구 `product` 라우터 제거 → `product-bulk-tool`로 대체
  - 프론트 요청 경로를 `product` → `product-bulk-tool`로 변경 필요

### 🏆 기대 효과
- 원천 데이터 조회와 대량 등록 유틸의 역할 분리로 관리성 향상
- 엑셀 처리 파이프라인을 API 단위로 노출하여 자동화 워크플로우 구성 용이
- 테스트 신뢰도 향상(Alembic 적용/의존성 모킹)

### 📂 주요 변경 파일
- `api/v1/endpoints/product_registration.py` (신규/대폭 수정)
- `api/v1/endpoints/product_bulk_tool.py` (신규)
- `repository/product_registration_repository.py` (수정)
- `repository/product_repository.py` (수정)
- `services/product_registration/product_registration_read_service.py` (신규)
- `schemas/product_registration/product_registration_dto.py` (신규/수정)
- `main.py` (라우터 포함)
- `tests/conftest.py`, `tests/fixtures/product/conftest.py` (테스트 설정)

### 📎 참고
- Pydantic v2: ORM 객체 → DTO 변환 시 `from_attributes=True` 필요
- 예: 서비스에서 변환 시
```python
ProductRegistrationDto.model_validate(product, from_attributes=True)
```
